### PR TITLE
Adds CLI args and option to launch profiles from CLI without constructing forms

### DIFF
--- a/GW Launcher/Forms/MainForm.cs
+++ b/GW Launcher/Forms/MainForm.cs
@@ -11,6 +11,7 @@ public partial class MainForm : Form
     private bool _keepOpen;
 
     private ListView.SelectedIndexCollection _selectedItems;
+    public bool autoCloseAfterLaunch;
     public readonly Queue<int> needtolaunch;
 
     public MainForm(bool launchMinimized = false)
@@ -27,6 +28,7 @@ public partial class MainForm : Form
         }
         InitializeComponent();
         var profilesToLaunch = ArgsManager.processProfileArgs();
+        autoCloseAfterLaunch = ArgsManager.processAutoCloseAfterLaunch();
         needtolaunch = new(profilesToLaunch);
         _selectedItems = new ListView.SelectedIndexCollection(listViewAccounts);
         _instance = this;

--- a/GW Launcher/Forms/MainForm.cs
+++ b/GW Launcher/Forms/MainForm.cs
@@ -11,7 +11,6 @@ public partial class MainForm : Form
     private bool _keepOpen;
 
     private ListView.SelectedIndexCollection _selectedItems;
-    public bool autoCloseAfterLaunch;
     public readonly Queue<int> needtolaunch;
 
     public MainForm(bool launchMinimized = false)
@@ -27,9 +26,7 @@ public partial class MainForm : Form
             Location = position;
         }
         InitializeComponent();
-        var profilesToLaunch = ArgsManager.processProfileArgs();
-        autoCloseAfterLaunch = ArgsManager.processAutoCloseAfterLaunch();
-        needtolaunch = new(profilesToLaunch);
+        needtolaunch = new();
         _selectedItems = new ListView.SelectedIndexCollection(listViewAccounts);
         _instance = this;
     }

--- a/GW Launcher/Forms/MainForm.cs
+++ b/GW Launcher/Forms/MainForm.cs
@@ -26,7 +26,8 @@ public partial class MainForm : Form
             Location = position;
         }
         InitializeComponent();
-        needtolaunch = new Queue<int>();
+        var profilesToLaunch = ArgsManager.processProfileArgs();
+        needtolaunch = new(profilesToLaunch);
         _selectedItems = new ListView.SelectedIndexCollection(listViewAccounts);
         _instance = this;
     }

--- a/GW Launcher/Forms/MainForm.cs
+++ b/GW Launcher/Forms/MainForm.cs
@@ -26,7 +26,7 @@ public partial class MainForm : Form
             Location = position;
         }
         InitializeComponent();
-        needtolaunch = new();
+        needtolaunch = new Queue<int>();
         _selectedItems = new ListView.SelectedIndexCollection(listViewAccounts);
         _instance = this;
     }

--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -181,6 +181,7 @@ GW Launcher will close.
             mainForm?.SetActive(accountIndex, true);
             GWMemory.FindAddressesIfNeeded(memory);
 
+
             Task.Run(() =>
             {
                 try
@@ -208,7 +209,6 @@ GW Launcher will close.
             UnlockMutex();
             Thread.Sleep(1000);
         }
-
     }
     
     private static bool LockMutex()

--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -1,5 +1,6 @@
 ﻿using GW_Launcher.Forms;
 using Octokit;
+using Account = GW_Launcher.Classes.Account;
 using Application = System.Windows.Forms.Application;
 using FileMode = System.IO.FileMode;
 using ThreadState = System.Threading.ThreadState;
@@ -86,8 +87,14 @@ GW Launcher will close.
                         break;
                     }
 
-                    var i = mainForm.needtolaunch.Dequeue();
-                    var account = accounts[i];
+                    Account account;
+                    var accountIndex = mainForm.needtolaunch.Dequeue();
+                    try { 
+                        account = accounts[accountIndex];
+                    } catch {
+                        MessageBox.Show($"Failed to launch account {accountIndex}");
+                        continue;
+                    }
                     if (!File.Exists(account.gwpath))
                     {
                         MessageBox.Show(@"Path to the Guild Wars executable incorrect, aborting launch.");
@@ -126,7 +133,7 @@ GW Launcher will close.
 
                     account.process = memory;
 
-                    mainForm.SetActive(i, true);
+                    mainForm.SetActive(accountIndex, true);
                     GWMemory.FindAddressesIfNeeded(memory);
 
                     Task.Run(() =>

--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -89,9 +89,12 @@ GW Launcher will close.
 
                     Account account;
                     var accountIndex = mainForm.needtolaunch.Dequeue();
-                    try { 
+                    try
+                    {
                         account = accounts[accountIndex];
-                    } catch {
+                    }
+                    catch
+                    {
                         MessageBox.Show($"Failed to launch account {accountIndex}");
                         continue;
                     }
@@ -187,7 +190,10 @@ GW Launcher will close.
                 }
 
                 UnlockMutex();
-
+                if (mainForm.autoCloseAfterLaunch)
+                {
+                    shouldClose = true;
+                }
                 Thread.Sleep(1000);
             }
 

--- a/GW Launcher/Utilities/ArgsManager.cs
+++ b/GW Launcher/Utilities/ArgsManager.cs
@@ -1,0 +1,33 @@
+﻿namespace GW_Launcher.Utilities;
+
+internal static class ArgsManager {
+    private static Dictionary<string, string> _commandLineArgs;
+    static ArgsManager() {
+        _commandLineArgs = GetCommandLineArgs();
+    }
+    public static List<int> processProfileArgs() {
+        List<int> profilesToLaunch = new();
+        if (_commandLineArgs.ContainsKey("profiles")) { 
+            var profiles = _commandLineArgs["profiles"];
+            foreach (var profile in  profiles.Split(',')) {
+                if (int.TryParse(profile, out int profileValue)) {
+                    profilesToLaunch.Add(profileValue);
+                }
+            }
+        }
+        return profilesToLaunch;
+    }
+
+    private static Dictionary<string, string> GetCommandLineArgs() {
+        var argsDictionary = new Dictionary<string, string>();
+        var args = Environment.GetCommandLineArgs().Skip(1);
+        foreach (var chunk in args.Chunk(2)) {
+            if (chunk.Length == 2) {
+                argsDictionary[chunk.First()] = chunk.Last();
+            }
+        }
+        return argsDictionary;
+    }
+
+
+}

--- a/GW Launcher/Utilities/ArgsManager.cs
+++ b/GW Launcher/Utilities/ArgsManager.cs
@@ -1,16 +1,29 @@
 ﻿namespace GW_Launcher.Utilities;
 
-internal static class ArgsManager {
+internal static class ArgsManager
+{
     private static Dictionary<string, string> _commandLineArgs;
-    static ArgsManager() {
+
+    static ArgsManager()
+    {
         _commandLineArgs = GetCommandLineArgs();
     }
-    public static List<int> processProfileArgs() {
+
+    public static bool processAutoCloseAfterLaunch()
+    {
+        return _commandLineArgs.ContainsKey("autoclose") && _commandLineArgs["autoclose"] == "true";
+    }
+
+    public static List<int> processProfileArgs()
+    {
         List<int> profilesToLaunch = new();
-        if (_commandLineArgs.ContainsKey("profiles")) { 
+        if (_commandLineArgs.ContainsKey("profiles"))
+        {
             var profiles = _commandLineArgs["profiles"];
-            foreach (var profile in  profiles.Split(',')) {
-                if (int.TryParse(profile, out int profileValue)) {
+            foreach (var profile in profiles.Split(','))
+            {
+                if (int.TryParse(profile, out int profileValue))
+                {
                     profilesToLaunch.Add(profileValue);
                 }
             }
@@ -18,16 +31,17 @@ internal static class ArgsManager {
         return profilesToLaunch;
     }
 
-    private static Dictionary<string, string> GetCommandLineArgs() {
+    private static Dictionary<string, string> GetCommandLineArgs()
+    {
         var argsDictionary = new Dictionary<string, string>();
         var args = Environment.GetCommandLineArgs().Skip(1);
-        foreach (var chunk in args.Chunk(2)) {
-            if (chunk.Length == 2) {
+        foreach (var chunk in args.Chunk(2))
+        {
+            if (chunk.Length == 2)
+            {
                 argsDictionary[chunk.First()] = chunk.Last();
             }
         }
         return argsDictionary;
     }
-
-
 }

--- a/GW Launcher/Utilities/ArgsManager.cs
+++ b/GW Launcher/Utilities/ArgsManager.cs
@@ -2,21 +2,17 @@
 
 internal static class ArgsManager
 {
-    private static Dictionary<string, string> _commandLineArgs;
+    public static bool hasArgs { get => _commandLineArgs.Count > 0; }
+    private static readonly Dictionary<string, string> _commandLineArgs;
 
     static ArgsManager()
     {
         _commandLineArgs = GetCommandLineArgs();
     }
 
-    public static bool processAutoCloseAfterLaunch()
+    public static Queue<int> ProcessProfilesArg()
     {
-        return _commandLineArgs.ContainsKey("autoclose") && _commandLineArgs["autoclose"] == "true";
-    }
-
-    public static List<int> processProfileArgs()
-    {
-        List<int> profilesToLaunch = new();
+        Queue<int> profilesToLaunch = new();
         if (_commandLineArgs.ContainsKey("profiles"))
         {
             var profiles = _commandLineArgs["profiles"];
@@ -24,7 +20,7 @@ internal static class ArgsManager
             {
                 if (int.TryParse(profile, out int profileValue))
                 {
-                    profilesToLaunch.Add(profileValue);
+                    profilesToLaunch.Enqueue(profileValue);
                 }
             }
         }


### PR DESCRIPTION
Hey, I wanted to help with something with gw.

This would close #53

---

Here's how you'd launch multiple profiles, if the profiles don't exist a message box will show.

In a `.bat` file:
```batch
@echo off
START /B "" "C:\<path/to/gwlauncher>\GW Launcher.exe" profiles 0,1,2
```

Code stuff:
I moved the account launching into a function and just reused it while trying to make as little changes to the code as I could. Accounts are loaded a bit earlier, since we need them to launch profiles.