### PR TITLE
Move rendering methods to the start of Main

### DIFF
--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -138,6 +138,9 @@ internal static class Program
     [STAThread]
     internal static void Main()
     {
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+
         if (!ParseCommandLineArgs())
         {
             Exit();
@@ -223,8 +226,6 @@ internal static class Program
         });
 
         // Main application
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
         mainForm = new MainForm(settings.LaunchMinimized);
         mainForm.FormClosed += (_, _) => { Exit(); };
         Application.Run(mainForm);


### PR DESCRIPTION
## Changes
- Moved the `SetCompatibleTextRenderingDefault` method which avoids an `InvalidOperationException` when launching the application
- Moved the `EnableVisualStyles` method for consistency

This should resolve: #86

Fixes:
```
Application: GW_Launcher.exe
CoreCLR Version: 8.0.524.21615
.NET Version: 8.0.5
Description: The process was terminated due to an unhandled exception.
Exception Info: System.InvalidOperationException: SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.
   at System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(Boolean defaultValue)
   at GW_Launcher.Program.Main()
```