### PR TITLE
HighDPI Screen Scaling

### DIFF
--- a/GW Launcher/Utilities/ScreenScaling.cs
+++ b/GW Launcher/Utilities/ScreenScaling.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GW_Launcher.Utilities;
+internal static class ScreenScaling
+{
+    [DllImport("gdi32.dll")]
+    static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+    private enum DeviceCap
+    {
+        VERTRES = 10,
+        DESKTOPVERTRES = 117,
+        //... http://pinvoke.net/default.aspx/gdi32/GetDeviceCaps.html
+    }
+
+    //get screen scaling factor set under settings -> system -> screen: scaling (e.g. 225%)
+    public static float GetScreenScalingFactor()
+    {
+        using Graphics g = Graphics.FromHwnd(IntPtr.Zero);
+        IntPtr desktop = g.GetHdc();
+
+        int logicalScreenHeight = GetDeviceCaps(desktop, (int)DeviceCap.VERTRES); //virtual screen resolution scaled down for DPI-unaware app
+        int physicalScreenHeight = GetDeviceCaps(desktop, (int)DeviceCap.DESKTOPVERTRES); //actual screen resolution, e.g. 3840 x 2160
+
+        g.ReleaseHdc(desktop);
+
+        float screenScalingFactor = physicalScreenHeight / (float) logicalScreenHeight;
+        return screenScalingFactor; // e.g. 1.25 = 125%
+    }
+}


### PR DESCRIPTION
This fixes issue #97:

Class ScreenScaling calculates the screen scaling factor set in windows under System -> Screen: Scaling (e.g. 225%) which is typically used for high screen resuolutions such as 4K screens.

MainForm::NotifyIcon_MouseClick calculation are fixed by taking into account the screen scaling factor - therefore MainForm will always be placed correctly on the screen for any scaling factor set.

Note: this change is completely transparent for users who don't use screen scaling and has no effect in this case:
X / 1 = X * 1 = X --> calculations remain unchanged

Note2: With this change the application remains DPI-unaware so no major redesign of the GUI is required