### PR TITLE
Added feature to reorder added game accounts in the gwlauncher window

### DIFF
--- a/GW Launcher/Forms/MainForm.Designer.cs
+++ b/GW Launcher/Forms/MainForm.Designer.cs
@@ -40,6 +40,8 @@ partial class MainForm
 		toolStripSeparator3 = new ToolStripSeparator();
 		toolStripMenuItemAddNew = new ToolStripMenuItem();
 		toolStripMenuItemEditSelected = new ToolStripMenuItem();
+		toolStripMenuItemMoveUp = new ToolStripMenuItem();
+		toolStripMenuItemMoveDown = new ToolStripMenuItem();
 		toolStripMenuItemCreateShortcut = new ToolStripMenuItem();
 		toolStripMenuItemRemoveSelected = new ToolStripMenuItem();
 		toolStripMenuItemLaunchSelected = new ToolStripMenuItem();
@@ -80,7 +82,7 @@ partial class MainForm
 		// 
 		// contextMenuStripAccounts
 		// 
-		contextMenuStripAccounts.Items.AddRange(new ToolStripItem[] { toolStripMenuItemRefreshAccounts, toolStripSeparator3, toolStripMenuItemAddNew, toolStripMenuItemEditSelected, toolStripMenuItemCreateShortcut, toolStripMenuItemRemoveSelected, toolStripMenuItemLaunchSelected, toolStripSeparator1, toolStripMenuItemLaunchGWInstance, toolStripMenuItemUpdateAllClients, toolStripSeparator2, toolStripMenuItemSettings });
+		contextMenuStripAccounts.Items.AddRange(new ToolStripItem[] { toolStripMenuItemRefreshAccounts, toolStripSeparator3, toolStripMenuItemAddNew, toolStripMenuItemEditSelected, toolStripMenuItemMoveUp, toolStripMenuItemMoveDown,toolStripMenuItemCreateShortcut, toolStripMenuItemRemoveSelected, toolStripMenuItemLaunchSelected, toolStripSeparator1, toolStripMenuItemLaunchGWInstance, toolStripMenuItemUpdateAllClients, toolStripSeparator2, toolStripMenuItemSettings });
 		contextMenuStripAccounts.Name = "contextMenuStripAccounts";
 		contextMenuStripAccounts.Size = new Size(211, 214);
 		contextMenuStripAccounts.Text = "Options.";
@@ -110,6 +112,20 @@ partial class MainForm
 		toolStripMenuItemEditSelected.Size = new Size(210, 22);
 		toolStripMenuItemEditSelected.Text = "Edit Selected";
 		toolStripMenuItemEditSelected.Click += ToolStripMenuItemEditSelected_Click;
+		//
+        // toolStripMenuItemMoveUp
+        //
+        toolStripMenuItemMoveUp.Name = "toolStripMenuItemMoveUp";
+        toolStripMenuItemMoveUp.Size = new Size(210, 22);
+        toolStripMenuItemMoveUp.Text = "Move Up";
+        toolStripMenuItemMoveUp.Click += ToolStripMenuItemMoveUp_Click;
+        //
+        // toolStripMenuItemMoveDown
+        //
+        toolStripMenuItemMoveDown.Name = "toolStripMenuItemMoveDown";
+        toolStripMenuItemMoveDown.Size = new Size(210, 22);
+        toolStripMenuItemMoveDown.Text = "Move Down";
+        toolStripMenuItemMoveDown.Click += ToolStripMenuItemMoveDown_Click;
 		// 
 		// toolStripMenuItemCreateShortcut
 		// 
@@ -203,6 +219,8 @@ partial class MainForm
 	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemLaunchGWInstance;
 	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemRefreshAccounts;
 	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemEditSelected;
+	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemMoveUp;
+    private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemMoveDown;
 	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemCreateShortcut;
 	private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 	private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemLaunchSelected;

--- a/GW Launcher/Forms/MainForm.cs
+++ b/GW Launcher/Forms/MainForm.cs
@@ -357,6 +357,52 @@ public partial class MainForm : Form
         addAccountForm.ShowDialog();
     }
 
+    private void ToolStripMenuItemMoveUp_Click(object sender, EventArgs e)
+    {
+        _selectedItems = listViewAccounts.SelectedIndices;
+        if (_selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        Program.mutex.WaitOne();
+        var indexes = from int index in _selectedItems orderby index descending select index;
+        foreach (var index in indexes)
+        {
+            if (index > 0)
+            {
+                Program.accounts.Move(index, index - 1);
+            }
+        }
+
+        Program.accounts.Save();
+        RefreshUI();
+        Program.mutex.ReleaseMutex();
+    }
+
+    private void ToolStripMenuItemMoveDown_Click(object sender, EventArgs e)
+    {
+        _selectedItems = listViewAccounts.SelectedIndices;
+        if (_selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        Program.mutex.WaitOne();
+        var indexes = from int index in _selectedItems orderby index select index;
+        foreach (var index in indexes)
+        {
+            if (index < Program.accounts.Length - 1)
+            {
+                Program.accounts.Move(index, index + 1);
+            }
+        }
+
+        Program.accounts.Save();
+        RefreshUI();
+        Program.mutex.ReleaseMutex();
+    }
+
     private void MainForm_Deactivate(object sender, EventArgs e)
     {
         if (!_keepOpen)

--- a/GW Launcher/Utilities/AccountManager.cs
+++ b/GW Launcher/Utilities/AccountManager.cs
@@ -85,6 +85,19 @@ public class AccountManager : IEnumerable<Account>, IDisposable
         return -1;
     }
 
+    public void Move(int oldIndex, int newIndex)
+    {
+        if (oldIndex < 0 || oldIndex >= Length || newIndex < 0 || newIndex >= Length)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        var account = _accounts[oldIndex];
+        _accounts.RemoveAt(oldIndex);
+        _accounts.Insert(newIndex, account);
+        Save(_filePath);
+    }
+
     public void Load(string? filePath = null)
     {
         if (Program.settings.Encrypt)


### PR DESCRIPTION
Adds “Move Up” and “Move Down” items to each account’s tool-strip menu, letting users change the account order directly in the GWLauncher window. Order is saved immediately.