### PR TITLE
Show sha256 prefix in launcher update prompt

### DIFF
--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -524,8 +524,15 @@ internal static class Program
 
         if (!Settings.AutoUpdate)
         {
+            // The version can match while the published binary changed (e.g. a re-signed release). The launcher
+            // decides up-to-date purely by sha256, so surface a short hash to make those rebuilds intelligible
+            // instead of a confusing "new version X" prompt when X is already installed.
+            var localSha = localPath != null ? GitHubAssets.ComputeSha256(localPath) : null;
+            var hashLine = GitHubAssets.ShortSha(localSha) is { } current
+                ? $"Installed: {tagName} ({current})\nLatest: {tagName} ({GitHubAssets.ShortSha(asset.Sha256)})"
+                : $"Latest: {tagName} ({GitHubAssets.ShortSha(asset.Sha256)})";
             var msgBoxResult = MessageBox.Show(
-                $@"New version {tagName} available. Download and install it now?",
+                $"A different build of GW Launcher is available.\n{hashLine}\nDownload and install it now?",
                 @"GW Launcher",
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Information,

--- a/GW Launcher/Utilities/GitHubAssets.cs
+++ b/GW Launcher/Utilities/GitHubAssets.cs
@@ -61,6 +61,14 @@ internal static class GitHubAssets
         return expectedSha256 == null || string.Equals(local, expectedSha256, StringComparison.OrdinalIgnoreCase);
     }
 
+    // Short, human-readable prefix of a sha256 hex string for display in update prompts.
+    public static string? ShortSha(string? sha256, int chars = 8)
+    {
+        if (string.IsNullOrEmpty(sha256))
+            return null;
+        return sha256.Length <= chars ? sha256 : sha256[..chars];
+    }
+
     private static string? ParseSha256(string? digest)
     {
         if (digest == null || !digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## What

When asking the user to update, the launcher prompt now shows a short sha256 prefix for the **installed** and **latest** builds, not just the version number.

## Why

The launcher decides whether it is up to date purely by comparing the local exe's sha256 against the published GitHub asset's sha256 — there is no stored "current version". A re-signed or rebuilt release (e.g. the Certum SimplySign signing change) keeps the same version tag but changes the binary hash, so `IsUpToDate` returns false and the old prompt said *"New version 18.1 available"* when 18.1 was already installed — exactly the confusion reported in #gwlauncher.

Showing the hash makes those rebuilds intelligible. Per @Jon's suggestion, this surfaces the first 8 chars of the sha256 alongside the version.

## Changes

- `Program.cs`: update prompt now reads e.g.
  ```
  A different build of GW Launcher is available.
  Installed: 18.1 (a1b2c3d4)
  Latest: 18.1 (e5f6a7b8)
  Download and install it now?
  ```
  (falls back to just the latest line when the local hash can't be computed)
- `GitHubAssets.ShortSha` helper (null-safe, default 8 chars)

Not built locally (no .NET toolchain in this environment); changes are straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)