### PR TITLE
fix(add account): don't save account when closing window without Save

### DIFF
--- a/GW Launcher/Forms/AddAccountForm.Designer.cs
+++ b/GW Launcher/Forms/AddAccountForm.Designer.cs
@@ -121,8 +121,7 @@ namespace GW_Launcher.Forms
 			buttonDone.Text = "Save";
 			buttonDone.UseCompatibleTextRendering = true;
 			buttonDone.UseVisualStyleBackColor = true;
-			buttonDone.Click += ButtonDone_Click;
-			// 
+			//
 			// labelPath
 			// 
 			labelPath.AutoSize = true;

--- a/GW Launcher/Forms/AddAccountForm.cs
+++ b/GW Launcher/Forms/AddAccountForm.cs
@@ -20,12 +20,15 @@ public partial class AddAccountForm : Form
 
 	protected override void OnFormClosing(FormClosingEventArgs e)
 	{
-		SaveAccount();
+		// buttonDone has DialogResult = OK set in the designer, so a Save click closes the
+		// form with DialogResult.OK. Any other close (X button, Escape, Alt+F4) must not
+		// persist the account.
+		if (DialogResult == DialogResult.OK)
+		{
+			SaveAccount();
+		}
+
 		base.OnFormClosing(e);
-	}
-	private void ButtonDone_Click(object sender, EventArgs e)
-	{
-		SaveAccount();
 	}
 	private void SaveAccount()
 	{


### PR DESCRIPTION
## Summary
- `AddAccountForm.OnFormClosing` unconditionally called `SaveAccount()`, so closing the "Add Account" window via the X button (or Escape/Alt+F4) created a new account with every field empty — the window never distinguished "closed via Save" from "closed any other way".
- `buttonDone` ("Save") already has `DialogResult = DialogResult.OK` set in the designer, so clicking it closes the form with `DialogResult.OK` before `OnFormClosing` runs. Now `OnFormClosing` only calls `SaveAccount()` when `DialogResult == DialogResult.OK`, i.e. only when Save was actually clicked. Any other close discards the in-progress edit.
- Dropped the now-redundant manual `SaveAccount()` call from the button's `Click` handler (it was previously calling `SaveAccount()` twice per Save click — once from `Click`, once from the subsequent `OnFormClosing`).

## Test plan
- [ ] Could not run a full build in this sandbox (this project needs the Windows-only .NET Framework MSBuild for `ResolveComReference`; confirmed pre-existing and unrelated to this change).
- [ ] Please verify on Windows: open "Add Account", close via the X button without touching any fields → no new account should appear in the list. Then open "Add Account" again, fill in fields, click Save → account should be saved as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)