### PR TITLE
fix(update check): treat an unparseable Gw.exe as out-of-date

### DIFF
--- a/GW Launcher/Program.cs
+++ b/GW Launcher/Program.cs
@@ -974,10 +974,11 @@ internal static class Program
             try
             {
                 var fileId = await Task.Run(() => new GuildWarsExecutableParser(gwpath).GetFileId(), ct);
-                if (fileId == 0)
-                    return (toUpdate: new List<Account>(), failedToCheck: accountsForPath);
                 if (fileId == latestFileId)
                     return (toUpdate: new List<Account>(), failedToCheck: new List<Account>());
+                // fileId == 0 means the build-id signature scan found nothing, which is what
+                // happens with an exe too old to match the current pattern. Treat that as
+                // out-of-date and offer an update rather than silently ignoring it.
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary
Follow-up to the thread where dropping in a very old `Gw.exe` produced no "out of date" message at all.

`RunUpdateCheck` (`Program.cs`) reads each account's local build id via `GuildWarsExecutableParser.GetFileId()`, which is a **signature scan** tuned to the current client layout (it looks for the `index < arrsize(s_eula)` assertion and surrounding code). A sufficiently old exe doesn't match that pattern, so `GetFileId()` returns `0`.

Previously `fileId == 0` was bucketed into **failed-to-check**, not **out-of-date**:
- The failed-to-check notice is only shown when `messageIfUpToDate == true`.
- The automatic startup check runs as `CheckForGwExeUpdates(false, false)`, so an unparseable old exe surfaced **nothing at all** — exactly the reported symptom.
- Even a manual check would only say "failed to check the version number", never offer to update it.

This change treats `fileId == 0` (parsed the PE fine, but not a recognisable current build) as **out-of-date**, so the account lands in the normal "These accounts are out-of-date — update now?" prompt. Genuine read/parse *exceptions* (locked file, malformed PE, etc.) still go to failed-to-check.

### Note / trade-off
If the id-signature scan ever breaks against a *current* build (a parser-maintenance bug), that build would be reported out-of-date and re-downloaded to the same version. That's a pre-existing risk of the signature approach and is fixed by keeping the parser current; it seemed preferable to silently reporting nothing when an exe genuinely is stale.

## Test plan
- [ ] Could not run a full build in this sandbox (pre-existing Windows-only MSBuild `ResolveComReference` limitation, unrelated to this one-line change).
- [ ] On Windows: point an account at an old `Gw.exe`, start the launcher → should now be prompted that the account is out-of-date and offered an update. Point an account at the current `Gw.exe` → should still report up-to-date / no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)